### PR TITLE
Fix for issue with saving blob.DeviceCredential to a file in arm32 platform

### DIFF
--- a/blob/credential.go
+++ b/blob/credential.go
@@ -20,8 +20,8 @@ import (
 // DeviceCredential contains all device state, including both public and private
 // parts of keys and secrets.
 type DeviceCredential struct {
-	Active bool
-	fdo.DeviceCredential
+	Active           bool
+	DeviceCredential fdo.DeviceCredential
 
 	// Secrets that would otherwise be stored inside a TPM or other enclave.
 	HmacSecret []byte
@@ -45,8 +45,8 @@ func (dc DeviceCredential) String() string {
   PrivateKey    %T
     %+v
   RvInfo
-`, dc.Active, dc.Version, dc.DeviceInfo, dc.GUID, dc.PublicKeyHash.Algorithm, dc.PublicKeyHash.Value, dc.HmacSecret, key, key)
-	for _, directive := range dc.RvInfo {
+`, dc.Active, dc.DeviceCredential.Version, dc.DeviceCredential.DeviceInfo, dc.DeviceCredential.GUID, dc.DeviceCredential.PublicKeyHash.Algorithm, dc.DeviceCredential.PublicKeyHash.Value, dc.HmacSecret, key, key)
+	for _, directive := range dc.DeviceCredential.RvInfo {
 		s += "    >\n"
 		for _, instruction := range directive {
 			s += fmt.Sprintf("      %d = %x\n", instruction.Variable, instruction.Value)

--- a/voucher_test.go
+++ b/voucher_test.go
@@ -148,7 +148,7 @@ func TestVerifyUnextendedVoucher(t *testing.T) {
 		t.Errorf("error verifying voucher cert chain hash: %v", err)
 	}
 
-	if err := ov.VerifyManufacturerKey(cred.PublicKeyHash); err != nil {
+	if err := ov.VerifyManufacturerKey(cred.DeviceCredential.PublicKeyHash); err != nil {
 		t.Errorf("error verifying voucher created by manufacturer key: %v", err)
 	}
 


### PR DESCRIPTION
Fix for Defect #6

Marshalling and unmarshalling of CBOR data works as expected for arm32-v5 platform.
Saving blob.DeviceCredential to file and reading works as expected with this fix.