### PR TITLE
Fix CBOR encoding of embedded struct fields

### DIFF
--- a/cbor/cbor.go
+++ b/cbor/cbor.go
@@ -1488,7 +1488,10 @@ func collectFieldWeights(parents []int, i, upper int, field func(int) reflect.St
 		}
 	}
 
-	// Return duplicates indices if flat (un)marshaling
+	// Duplicate parents slice, because it might be appended to
+	parents = slices.Clone(parents)
+
+	// Return duplicate indices if flat (un)marshaling
 	if n, ok := flatN(f); ok {
 		for j := 0; j < n; j++ {
 			fields = append(fields, weightedField{


### PR DESCRIPTION
Fixes #6

Replaces #9

Updated CBOR tests failed for ARM32 due to the parents slice being appended to with different indices in `collectFieldWeights`. On ARM32 the backing array wasn't changing, so the value was being overwritten, resulting in field orders like `[0 [1 2] [1 2] [1 2]]` instead of `[0 [1 0] [1 1] [1 2]]`.

Testing was performed using QEMU:

```console
> GOARCH=arm GOARM=5 go test -c -o test.arm32 ./cbor
> qemu-arm ./test.arm32 -test.run codeArray
--- FAIL: TestEncodeArray (0.01s)
    --- FAIL: TestEncodeArray/tuples (0.00s)
        cbor_test.go:378: marshaling struct { cbor_test.Embed; B []int "cbor:\"2\"" }{Embed:cbor_test.Embed{A:1, B:[]int{2, 3}, C:"IETF", D:[]uint8{0x48, 0x65, 0x6c, 0x6c, 0x6f}}, B:[]int{3, 4}}; expected 84 01 82 03 04 64 49 45 54 46 45 48 65 6c 6c 6f, got 84 45 48 65 6c 6c 6f 82 03 04 45 48 65 6c 6c 6f
--- FAIL: TestDecodeArray (0.01s)
    --- FAIL: TestDecodeArray/tuples (0.00s)
        cbor_test.go:1174: error unmarshaling 84 01 82 03 04 64 49 45 54 46 45 48 65 6c 6c 6f: error decoding array item [0 3]: unsupported type: []uint8: only primitive (u)int(N) types supported
FAIL
```

The fix was to clone the parents slice before appending to it and passing to the recursive func.