### PR TITLE
tpm: Allow devices with indexes greater than 0, e.g. /dev/tpmrm1

### DIFF
--- a/tpm/alias_test.go
+++ b/tpm/alias_test.go
@@ -1,0 +1,7 @@
+// SPDX-FileCopyrightText: (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
+
+package tpm
+
+// IsDevNode aliases the private function for testing.
+var IsDevNode = isDevNode

--- a/tpm/tpm_test.go
+++ b/tpm/tpm_test.go
@@ -17,6 +17,65 @@ import (
 	"github.com/fido-device-onboard/go-fdo/tpm"
 )
 
+func TestIsDevNode(t *testing.T) {
+	for _, test := range []struct {
+		path   string
+		kind   string
+		expect bool
+	}{
+		{
+			path:   "/dev/tpm0",
+			kind:   "tpm",
+			expect: true,
+		},
+		{
+			path:   "/dev/tpm1",
+			kind:   "tpm",
+			expect: true,
+		},
+		{
+			path:   "/dev/tpmrm0",
+			kind:   "tpmrm",
+			expect: true,
+		},
+		{
+			path:   "/dev/tpmrm1",
+			kind:   "tpmrm",
+			expect: true,
+		},
+		{
+			path:   "/dev/tpm0",
+			kind:   "tpmrm",
+			expect: false,
+		},
+		{
+			path:   "/dev/tpmrm0",
+			kind:   "tpm",
+			expect: false,
+		},
+		{
+			path:   "/dev/tpmrm0",
+			kind:   "tpmrm0",
+			expect: false,
+		},
+		{
+			path:   "tpmrm0",
+			kind:   "tpmrm",
+			expect: false,
+		},
+	} {
+		t.Run("whether "+test.path+" is a "+test.kind, func(t *testing.T) {
+			if got, expect := tpm.IsDevNode(test.path, test.kind), test.expect; got != expect {
+				var direction string
+				if !expect {
+					direction = " not"
+				}
+				t.Errorf("expected %q to%s match %q suffixed with a number", test.path, direction, test.kind)
+			}
+		})
+	}
+}
+
 func TestTPMDevice(t *testing.T) {
 	sim, err := simulator.OpenSimulator()
 	if err != nil {


### PR DESCRIPTION
Fixes #51 