### PR TITLE
tpm: export IsDevNode

### DIFF
--- a/tpm/alias_test.go
+++ b/tpm/alias_test.go
@@ -1,7 +1,0 @@
-// SPDX-FileCopyrightText: (C) 2025 Intel Corporation
-// SPDX-License-Identifier: Apache 2.0
-
-package tpm
-
-// IsDevNode aliases the private function for testing.
-var IsDevNode = isDevNode

--- a/tpm/tpm.go
+++ b/tpm/tpm.go
@@ -30,16 +30,16 @@ type Closer interface {
 	io.Closer
 }
 
-// Open a TPM device at the given path.
+// OpenUnix opens a TPM device at the given path.
 //
 // Clients should use /dev/tpmrm0 because using /dev/tpm0 requires more
 // extensive resource management that the kernel already handles for us
 // when using the kernel resource manager.
-func Open(path string) (Closer, error) {
+func OpenUnix(path string) (Closer, error) {
 	switch {
-	case IsDevNode(path, DevNodeManaged):
+	case isDevNode(path, DevNodeManaged):
 		return linuxtpm.Open(path)
-	case IsDevNode(path, DevNodeUnmanaged):
+	case isDevNode(path, DevNodeUnmanaged):
 		slog.Warn("direct use of the TPM can lead to resource exhaustion, use a TPM resource manager instead")
 		return linuxtpm.Open(path)
 	default:
@@ -74,7 +74,7 @@ const (
 
 // IsDevNode checks that path is a device node at the standard unix path for
 // kind.
-func IsDevNode(path string, kind DevNodeKind) bool {
+func isDevNode(path string, kind DevNodeKind) bool {
 	path = filepath.Clean(path)
 
 	// Check path has appropriate prefix and numerical index

--- a/tpm/tpm.go
+++ b/tpm/tpm.go
@@ -35,9 +35,9 @@ type Closer interface {
 // when using the kernel resource manager.
 func Open(path string) (Closer, error) {
 	switch {
-	case isDevNode(path, "tpmrm"):
+	case IsDevNode(path, "tpmrm"):
 		return linuxtpm.Open(path)
-	case isDevNode(path, "tpm"):
+	case IsDevNode(path, "tpm"):
 		slog.Warn("direct use of the TPM can lead to resource exhaustion, use a TPM resource manager instead")
 		return linuxtpm.Open(path)
 	default:
@@ -45,7 +45,7 @@ func Open(path string) (Closer, error) {
 	}
 }
 
-func isDevNode(path, kind string) bool {
+func IsDevNode(path, kind string) bool {
 	if strings.Contains(kind, "/") {
 		return false
 	}

--- a/tpm/tpm_test.go
+++ b/tpm/tpm_test.go
@@ -20,57 +20,52 @@ import (
 func TestIsDevNode(t *testing.T) {
 	for _, test := range []struct {
 		path   string
-		kind   string
+		kind   tpm.DevNodeKind
 		expect bool
 	}{
 		{
 			path:   "/dev/tpm0",
-			kind:   "tpm",
+			kind:   tpm.DevNodeUnmanaged,
 			expect: true,
 		},
 		{
 			path:   "/dev/tpm1",
-			kind:   "tpm",
+			kind:   tpm.DevNodeUnmanaged,
 			expect: true,
 		},
 		{
 			path:   "/dev/tpmrm0",
-			kind:   "tpmrm",
+			kind:   tpm.DevNodeManaged,
 			expect: true,
 		},
 		{
 			path:   "/dev/tpmrm1",
-			kind:   "tpmrm",
+			kind:   tpm.DevNodeManaged,
 			expect: true,
 		},
 		{
 			path:   "/dev/tpm0",
-			kind:   "tpmrm",
+			kind:   tpm.DevNodeManaged,
 			expect: false,
 		},
 		{
 			path:   "/dev/tpmrm0",
-			kind:   "tpm",
-			expect: false,
-		},
-		{
-			path:   "/dev/tpmrm0",
-			kind:   "tpmrm0",
+			kind:   tpm.DevNodeUnmanaged,
 			expect: false,
 		},
 		{
 			path:   "tpmrm0",
-			kind:   "tpmrm",
+			kind:   tpm.DevNodeManaged,
 			expect: false,
 		},
 	} {
-		t.Run("whether "+test.path+" is a "+test.kind, func(t *testing.T) {
+		t.Run("whether "+test.path+" is a "+test.kind.PathPrefix(), func(t *testing.T) {
 			if got, expect := tpm.IsDevNode(test.path, test.kind), test.expect; got != expect {
 				var direction string
 				if !expect {
 					direction = " not"
 				}
-				t.Errorf("expected %q to%s match %q suffixed with a number", test.path, direction, test.kind)
+				t.Errorf("expected %q to%s match %q suffixed with a number", test.path, direction, test.kind.PathPrefix())
 			}
 		})
 	}


### PR DESCRIPTION
Allows to be reused by implementors w/o rewriting and retesting it.