### PR TITLE
Make DI, TO0, and TO2 server configuration options more general and fallible

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,7 +22,7 @@ linters:
       - path: (.+)\.go$
         text: declaration of "(err|ctx)" shadows declaration at
       - path: (.+)\.go$
-        text: '^unused-parameter: '
+        text: "^unused-parameter: "
     paths:
       - third_party$
       - builtin$

--- a/aio.go
+++ b/aio.go
@@ -1,0 +1,168 @@
+// SPDX-FileCopyrightText: (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
+
+package fdo
+
+import (
+	"context"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/rsa"
+	"crypto/x509"
+	"fmt"
+	"time"
+
+	"github.com/fido-device-onboard/go-fdo/cbor"
+	"github.com/fido-device-onboard/go-fdo/cose"
+	"github.com/fido-device-onboard/go-fdo/protocol"
+)
+
+// AllInOne is a construct with functionality that is only possible when
+// different FDO services are combined.
+type AllInOne struct {
+	// A combination DI and Owner service can auto-extend vouchers for itself.
+	DIAndOwner interface {
+		// ManufacturerKey returns the signer of a given key type and its
+		// certificate chain (required). If key type is not RSAPKCS or RSAPSS
+		// then rsaBits is ignored. Otherwise it must be either 2048 or 3072.
+		ManufacturerKey(ctx context.Context, keyType protocol.KeyType, rsaBits int) (crypto.Signer, []*x509.Certificate, error)
+
+		// OwnerKey returns the private key matching a given key type and
+		// optionally its certificate chain. If key type is not RSAPKCS or
+		// RSAPSS then rsaBits is ignored. Otherwise it must be either 2048 or
+		// 3072.
+		OwnerKey(ctx context.Context, keyType protocol.KeyType, rsaBits int) (crypto.Signer, []*x509.Certificate, error)
+	}
+
+	// A combination Rendezvous and Owner service can auto-register devices for
+	// rendezvous
+	RendezvousAndOwner interface {
+		// SetRVBlob sets the owner rendezvous blob for a device.
+		SetRVBlob(context.Context, *Voucher, *cose.Sign1[protocol.To1d, []byte], time.Time) error
+
+		// OwnerKey returns the private key matching a given key type and
+		// optionally its certificate chain. If key type is not RSAPKCS or
+		// RSAPSS then rsaBits is ignored. Otherwise it must be either 2048 or
+		// 3072.
+		OwnerKey(ctx context.Context, keyType protocol.KeyType, rsaBits int) (crypto.Signer, []*x509.Certificate, error)
+
+		// OwnerAddrs are the owner service addresses to register with the
+		// rendezvous service and the expiration duration. If the duration is
+		// zero, then a default of 30 years will be used.
+		OwnerAddrs(context.Context, Voucher) ([]protocol.RvTO2Addr, time.Duration, error)
+	}
+}
+
+// Extend a voucher and replace the value pointed to with the newly extended
+// voucher.
+//
+// This function is meant to be used as a callback in DIServer.
+func (aio AllInOne) Extend(ctx context.Context, ov *Voucher) error {
+	if aio.DIAndOwner == nil {
+		panic("DIAndOwner must be set")
+	}
+
+	mfgKey := ov.Header.Val.ManufacturerKey
+	keyType, rsaBits := mfgKey.Type, mfgKey.RsaBits()
+	owner, _, err := aio.DIAndOwner.ManufacturerKey(ctx, keyType, rsaBits)
+	if err != nil {
+		return fmt.Errorf("auto extend: error getting %s manufacturer key: %w", keyType, err)
+	}
+	nextOwner, _, err := aio.DIAndOwner.OwnerKey(ctx, keyType, rsaBits)
+	if err != nil {
+		return fmt.Errorf("auto extend: error getting %s owner key: %w", keyType, err)
+	}
+	switch owner.Public().(type) {
+	case *ecdsa.PublicKey:
+		nextOwner, ok := nextOwner.Public().(*ecdsa.PublicKey)
+		if !ok {
+			return fmt.Errorf("auto extend: owner key must be %s", keyType)
+		}
+		extended, err := ExtendVoucher(ov, owner, nextOwner, nil)
+		if err != nil {
+			return err
+		}
+		*ov = *extended
+		return nil
+
+	case *rsa.PublicKey:
+		nextOwner, ok := nextOwner.Public().(*rsa.PublicKey)
+		if !ok {
+			return fmt.Errorf("auto extend: owner key must be %s", keyType)
+		}
+		extended, err := ExtendVoucher(ov, owner, nextOwner, nil)
+		if err != nil {
+			return err
+		}
+		*ov = *extended
+		return nil
+
+	default:
+		return fmt.Errorf("auto extend: invalid key type %T", owner)
+	}
+}
+
+// RegisterOwnerAddr sets the owner service address for the device to discover
+// in TO1.
+//
+// This function is meant to be used as a callback in DIServer.
+func (aio AllInOne) RegisterOwnerAddr(ctx context.Context, ov Voucher) error {
+	if aio.RendezvousAndOwner == nil {
+		panic("RendezvousAndOwner must be set")
+	}
+
+	mfgKey := ov.Header.Val.ManufacturerKey
+	keyType, rsaBits := mfgKey.Type, mfgKey.RsaBits()
+	nextOwner, _, err := aio.RendezvousAndOwner.OwnerKey(ctx, keyType, rsaBits)
+	if err != nil {
+		return fmt.Errorf("auto-to0: error getting %s owner key: %w", keyType, err)
+	}
+
+	var opts crypto.SignerOpts
+	switch keyType {
+	case protocol.Rsa2048RestrKeyType, protocol.RsaPkcsKeyType, protocol.RsaPssKeyType:
+		switch rsaPub := nextOwner.Public().(*rsa.PublicKey); rsaPub.Size() {
+		case 2048 / 8:
+			opts = crypto.SHA256
+		case 3072 / 8:
+			opts = crypto.SHA384
+		default:
+			return fmt.Errorf("auto-to0: unsupported RSA key size: %d bits", rsaPub.Size()*8)
+		}
+
+		if keyType == protocol.RsaPssKeyType {
+			opts = &rsa.PSSOptions{
+				SaltLength: rsa.PSSSaltLengthEqualsHash,
+				Hash:       opts.(crypto.Hash),
+			}
+		}
+	}
+
+	ownerAddrs, expDur, err := aio.RendezvousAndOwner.OwnerAddrs(ctx, ov)
+	if err != nil {
+		return fmt.Errorf("auto-to0: error getting owner service address(es): %w", err)
+	}
+	sign1 := cose.Sign1[protocol.To1d, []byte]{
+		Payload: cbor.NewByteWrap(protocol.To1d{
+			RV: ownerAddrs,
+			To0dHash: protocol.Hash{
+				Algorithm: protocol.Sha256Hash,
+				Value:     make([]byte, 32),
+			},
+		}),
+	}
+	if err := sign1.Sign(nextOwner, nil, nil, opts); err != nil {
+		return fmt.Errorf("auto-to0: error signing to1d: %w", err)
+	}
+
+	// Default to expiring in 30 years
+	exp := time.Now().Add(expDur)
+	if expDur <= 0 {
+		exp = exp.AddDate(30, 0, 0)
+	}
+	if err := aio.RendezvousAndOwner.SetRVBlob(ctx, &ov, &sign1, exp); err != nil {
+		return fmt.Errorf("auto-to0: error storing to1d: %w", err)
+	}
+
+	return nil
+}

--- a/fdotest/client.go
+++ b/fdotest/client.go
@@ -184,7 +184,7 @@ func RunClientTestSuite(t *testing.T, conf Config) {
 			chain = append([]*x509.Certificate{cert}, chain...)
 			return chain, nil
 		},
-		AutoExtend: conf.State,
+		BeforeVoucherPersist: fdo.AllInOne{DIAndOwner: conf.State}.Extend,
 		RvInfo: func(context.Context, *fdo.Voucher) ([][]protocol.RvInstruction, error) {
 			return [][]protocol.RvInstruction{}, nil
 		},
@@ -222,7 +222,7 @@ func RunClientTestSuite(t *testing.T, conf Config) {
 		RvInfo: func(context.Context, fdo.Voucher) ([][]protocol.RvInstruction, error) {
 			return [][]protocol.RvInstruction{}, nil
 		},
-		ReuseCredential: func(context.Context, fdo.Voucher) bool { return conf.Reuse },
+		ReuseCredential: func(context.Context, fdo.Voucher) (bool, error) { return conf.Reuse, nil },
 		VerifyVoucher:   func(context.Context, fdo.Voucher) error { return nil },
 	}
 

--- a/fdotest/internal/memory/memory.go
+++ b/fdotest/internal/memory/memory.go
@@ -45,7 +45,6 @@ var _ fdo.RendezvousBlobPersistentState = (*State)(nil)
 var _ fdo.ManufacturerVoucherPersistentState = (*State)(nil)
 var _ fdo.OwnerVoucherPersistentState = (*State)(nil)
 var _ fdo.OwnerKeyPersistentState = (*State)(nil)
-var _ fdo.AutoExtend = (*State)(nil)
 
 // NewState initializes the in-memory state.
 func NewState() (*State, error) {

--- a/server_state.go
+++ b/server_state.go
@@ -192,35 +192,3 @@ type OwnerVoucherPersistentState interface {
 	// Voucher retrieves a voucher by GUID.
 	Voucher(context.Context, protocol.GUID) (*Voucher, error)
 }
-
-// The following types are for optional server features.
-
-// AutoExtend provides the necessary methods for automatically extending a
-// device voucher upon the completion of DI.
-type AutoExtend interface {
-	// ManufacturerKey returns the signer of a given key type and its certificate
-	// chain (required). If key type is not RSAPKCS or RSAPSS then rsaBits is
-	// ignored. Otherwise it must be either 2048 or 3072.
-	//
-	// The context may hold additional data for selecting the key.
-	ManufacturerKey(ctx context.Context, keyType protocol.KeyType, rsaBits int) (crypto.Signer, []*x509.Certificate, error)
-
-	// OwnerKey returns the private key matching a given key type and optionally
-	// its certificate chain. If key type is not RSAPKCS or RSAPSS then rsaBits
-	// is ignored. Otherwise it must be either 2048 or 3072.
-	//
-	// The context may hold additional data for selecting the key.
-	OwnerKey(ctx context.Context, keyType protocol.KeyType, rsaBits int) (crypto.Signer, []*x509.Certificate, error)
-}
-
-// AutoTO0 provides the necessary methods for setting a rendezvous blob upon
-// device voucher auto-extension.
-type AutoTO0 interface {
-	// OwnerKey returns the private key matching a given key type and optionally
-	// its certificate chain. If key type is not RSAPKCS or RSAPSS then rsaBits
-	// is ignored. Otherwise it must be either 2048 or 3072.
-	OwnerKey(ctx context.Context, keyType protocol.KeyType, rsaBits int) (crypto.Signer, []*x509.Certificate, error)
-
-	// SetRVBlob sets the owner rendezvous blob for a device.
-	SetRVBlob(context.Context, *Voucher, *cose.Sign1[protocol.To1d, []byte], time.Time) error
-}

--- a/sqlite/sqlite.go
+++ b/sqlite/sqlite.go
@@ -191,8 +191,6 @@ var _ interface {
 	fdo.ManufacturerVoucherPersistentState
 	fdo.OwnerVoucherPersistentState
 	fdo.OwnerKeyPersistentState
-	fdo.AutoExtend
-	fdo.AutoTO0
 } = (*DB)(nil)
 
 const sessionIDSize = 16


### PR DESCRIPTION
- DIServer: Replace AutoExtend/AutoTO0 fields with BeforeVoucherPersist/AfterVoucherPersist
- TO0Server: Combine NegotiateTTL into AcceptVoucher
- TO2Server: Allow error from ReuseCredential and MaxDeviceServiceInfoSize funcs

Closes #91
