### PR TITLE
Fix possible panic in `(*serviceinfo.UnchunkWriter).NextServiceInfo `

### DIFF
--- a/to2.go
+++ b/to2.go
@@ -1471,6 +1471,8 @@ func (s *TO2Server) ownerServiceInfo(ctx context.Context, msg io.Reader) (*owner
 			Devmod:  devmod,
 			Modules: modules,
 		}
+	} else if err != nil {
+		return nil, fmt.Errorf("error getting devmod state: %w", err)
 	} else {
 		var err error
 		moduleName, module, err = s.Modules.Module(ctx)


### PR DESCRIPTION
This may occur when `Close`d inside `nextPipe`, as observed by @bkgoodman when TO2 failed in the middle of the client sending devmod serviceinfo.

Also fixed a missing error-handling branch that would occur in the case of an outdated database schema missing devmod columns in the TO2 session table.