### PR TITLE
fix: RVDelaysec parsing type mismatch

### DIFF
--- a/protocol/rv.go
+++ b/protocol/rv.go
@@ -211,9 +211,9 @@ func parseDirective(vars []RvInstruction, device bool) *RvDirective { //nolint:g
 			}
 
 		case RVDelaysec:
-			var secs time.Duration
+			var secs uint32
 			if err := cbor.Unmarshal(v.Value, &secs); err == nil {
-				dir.Delay = secs * time.Second
+				dir.Delay = time.Duration(secs) * time.Second
 			}
 
 		case RVSvCertHash:


### PR DESCRIPTION
fixes https://github.com/fido-device-onboard/go-fdo/issues/181 
Change var secs from time.Duration to uint32 to match CBOR encoding.