### PR TITLE
Add More Convenience Values to `serviceinfo.Context`

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -50,29 +50,31 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v3.29.5
+        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           languages: ${{ matrix.language }}
+          build-mode: manual
           # If you wish to specify custom queries, you can do so here or in a config file.
           # By default, queries listed here will override any specified in a config file.
           # Prefix the list here with "+" to use these queries and those in the config file.
 
-      # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-      # If this step fails, then you should remove it and run the build manually (see below)
-      - name: Autobuild
-        uses: github/codeql-action/autobuild@b20883b0cd1f46c72ae0ba6d1090936928f9fa30 # v3.29.5
+      # Build each module so CodeQL traces all Go packages in the repository.
+      - name: Build base library
+        run: go build ./...
 
-      # ℹ️ Command-line programs to run using the OS shell.
-      # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+      - name: Build FSIM
+        run: go -C fsim build ./...
 
-      #   If the Autobuild fails above, remove it and uncomment the following three lines.
-      #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
+      - name: Build sqlite
+        run: go -C sqlite build ./...
 
-      # - run: |
-      #   echo "Run, Build Application using script"
-      #   ./location_of_script_within_repo/buildscript.sh
+      - name: Build TPM
+        run: go -C tpm build ./...
+
+      - name: Build examples
+        run: go -C examples build ./...
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v3.29.5
+        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           category: "/language:${{matrix.language}}"

--- a/flake.nix
+++ b/flake.nix
@@ -116,6 +116,7 @@
             go_1_25
             gotools
             gomod2nix.packages.${system}.default
+            golangci-lint
           ];
           nativeBuildInputs = with pkgs; [
             openssl
@@ -128,6 +129,7 @@
             go_1_25
             gotools
             gomod2nix.packages.${system}.default
+            golangci-lint
           ];
           nativeBuildInputs = with pkgs; [
             openssl

--- a/server_state.go
+++ b/server_state.go
@@ -141,10 +141,10 @@ type TO2SessionState interface {
 	MTU(context.Context) (uint16, error)
 
 	// SetDevmod sets the device info and module support.
-	SetDevmod(_ context.Context, _ serviceinfo.Devmod, modules []string, complete bool) error
+	SetDevmod(_ context.Context, _ serviceinfo.Devmod, supportedModules []string, complete bool) error
 
 	// Devmod returns the device info and module support.
-	Devmod(context.Context) (_ serviceinfo.Devmod, modules []string, complete bool, _ error)
+	Devmod(context.Context) (_ serviceinfo.Devmod, supportedModules []string, complete bool, _ error)
 }
 
 // RendezvousBlobPersistentState maintains device to owner info state used in

--- a/serviceinfo/context.go
+++ b/serviceinfo/context.go
@@ -6,19 +6,27 @@ package serviceinfo
 import (
 	"context"
 	"crypto/x509"
+
+	"github.com/fido-device-onboard/go-fdo/protocol"
 )
 
 type (
-	devmodKey struct{}
-	devcrtKey struct{}
+	devmodKey           struct{}
+	supportedModulesKey struct{}
+	deviceCertKey       struct{}
+	guidKey             struct{}
+	replacementGUIDKey  struct{}
 )
 
 // Context creates a context with the values expected by native FSIM
 // implementations.
-func Context(parent context.Context, devmod *Devmod, devCert []*x509.Certificate) context.Context {
-	return context.WithValue(context.WithValue(parent,
+func Context(parent context.Context, devmod *Devmod, supportedModules []string, deviceCertChain []*x509.Certificate, guid, replacement protocol.GUID) context.Context {
+	return context.WithValue(context.WithValue(context.WithValue(context.WithValue(context.WithValue(parent,
 		devmodKey{}, devmod),
-		devcrtKey{}, devCert)
+		supportedModulesKey{}, supportedModules),
+		deviceCertKey{}, deviceCertChain),
+		guidKey{}, guid),
+		replacementGUIDKey{}, replacement)
 }
 
 // DevmodFromContext returns the devmod for the current session. The ctx must
@@ -28,10 +36,34 @@ func DevmodFromContext(ctx context.Context) (devmod *Devmod, ok bool) {
 	return
 }
 
+// DeviceSupportedModulesFromContext returns the supported modules for the
+// current session. The ctx must be from the first argument of HandleInfo or
+// ProduceInfo for an OwnerModule.
+func DeviceSupportedModulesFromContext(ctx context.Context) (supported []string, ok bool) {
+	supported, ok = ctx.Value(supportedModulesKey{}).([]string)
+	return
+}
+
 // DeviceCertificateFromContext returns the device certificate chain for the
 // current session. The ctx must be from the first argument of HandleInfo or
 // ProduceInfo for an OwnerModule.
 func DeviceCertificateFromContext(ctx context.Context) (devCert []*x509.Certificate, ok bool) {
-	devCert, ok = ctx.Value(devcrtKey{}).([]*x509.Certificate)
+	devCert, ok = ctx.Value(deviceCertKey{}).([]*x509.Certificate)
+	return
+}
+
+// GUIDFromContext returns the device GUID for the current session. The ctx
+// must be from the first argument of HandleInfo or ProduceInfo for an
+// OwnerModule.
+func GUIDFromContext(ctx context.Context) (guid protocol.GUID, ok bool) {
+	guid, ok = ctx.Value(guidKey{}).(protocol.GUID)
+	return
+}
+
+// ReplacementGUIDFromContext returns the GUID the device will have if TO2
+// succeeds. The ctx must be from the first argument of HandleInfo or
+// ProduceInfo for an OwnerModule.
+func ReplacementGUIDFromContext(ctx context.Context) (replacement protocol.GUID, ok bool) {
+	replacement, ok = ctx.Value(guidKey{}).(protocol.GUID)
 	return
 }

--- a/serviceinfo/context_test.go
+++ b/serviceinfo/context_test.go
@@ -19,8 +19,9 @@ const mockModuleName = "fdotest.mock"
 
 func TestOwnerModuleContextValues(t *testing.T) {
 	var (
-		expectedDevmod    *serviceinfo.Devmod
-		expectedCertChain []*x509.Certificate
+		expectedDevmod        *serviceinfo.Devmod
+		expectedSupportedMods []string
+		expectedCertChain     []*x509.Certificate
 	)
 
 	deviceModule := &fdotest.MockDeviceModule{}
@@ -30,6 +31,12 @@ func TestOwnerModuleContextValues(t *testing.T) {
 				t.Error("devmod from context is empty")
 			} else if !reflect.DeepEqual(expectedDevmod, gotDevmod) {
 				t.Errorf("expected devmod %+v, got %+v", *expectedDevmod, *gotDevmod)
+			}
+
+			if gotSupportedMods, ok := serviceinfo.DeviceSupportedModulesFromContext(ctx); !ok {
+				t.Error("device supported mods from context is empty")
+			} else if !reflect.DeepEqual(expectedSupportedMods, gotSupportedMods) {
+				t.Errorf("expected device supported mods %+v, got %+v", expectedSupportedMods, gotSupportedMods)
 			}
 
 			if gotCertChain, ok := serviceinfo.DeviceCertificateFromContext(ctx); !ok {
@@ -48,6 +55,7 @@ func TestOwnerModuleContextValues(t *testing.T) {
 		},
 		OwnerModules: func(ctx context.Context, replacementGUID protocol.GUID, info string, chain []*x509.Certificate, devmod serviceinfo.Devmod, supportedMods []string) iter.Seq2[string, serviceinfo.OwnerModule] {
 			expectedDevmod = &devmod
+			expectedSupportedMods = supportedMods
 			expectedCertChain = chain
 			return func(yield func(string, serviceinfo.OwnerModule) bool) { yield(mockModuleName, ownerModule) }
 		},


### PR DESCRIPTION
Also use `serviceinfo.Context` for `serviceinfo.ModuleStateMachine` methods. This is not required, but is helpful, because it means that implementations of `serviceinfo.ModuleStateMachine` do not need to hold a database connection to lookup the devmod, supported modules, and device certificate chain for the current session.