### PR TITLE
fix: handle cross-filesystem moves in fdo.download and fdo.wget

### DIFF
--- a/fsim/download_device.go
+++ b/fsim/download_device.go
@@ -146,7 +146,7 @@ func (d *Download) finalize(respond func(string) io.Writer) error {
 		return cbor.NewEncoder(respond("done")).Encode(-1)
 	}
 
-	// Rename temp file to final file name
+	// Move temp file to final file name
 	resolveName := d.NameToPath
 	if resolveName == nil {
 		resolveName = func(name string) string { return name }
@@ -157,9 +157,9 @@ func (d *Download) finalize(respond func(string) io.Writer) error {
 		}
 		return fmt.Errorf("name not sent before data transfer completed")
 	}
-	if err := os.Rename(d.temp.Name(), resolveName(d.name)); err != nil {
+	if err := moveFile(d.temp.Name(), resolveName(d.name)); err != nil {
 		if d.ErrorLog != nil {
-			_, _ = fmt.Fprintf(d.ErrorLog, "[file=%s] error renaming file: %v\n", d.name, err)
+			_, _ = fmt.Fprintf(d.ErrorLog, "[file=%s] error moving file: %v\n", d.name, err)
 		}
 		return cbor.NewEncoder(respond("done")).Encode(-1)
 	}

--- a/fsim/fsim.go
+++ b/fsim/fsim.go
@@ -8,9 +8,86 @@ package fsim
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"io"
 	"log/slog"
+	"os"
+	"syscall"
 )
 
 func debugEnabled() bool {
 	return slog.Default().Enabled(context.Background(), slog.LevelDebug)
+}
+
+// moveFile moves a file from src to dst, using efficient os.Rename when
+// possible, and falling back to io.Copy for cross-filesystem moves.
+// This supports architectures like RHEL/Fedora where /tmp is on tmpfs
+// (a separate RAM-based filesystem) while target directories are on disk.
+func moveFile(src, dst string) error {
+	// Try efficient rename first (works when src and dst are on same filesystem)
+	err := os.Rename(src, dst)
+	if err == nil {
+		return nil
+	}
+
+	// Check if error is due to cross-filesystem move
+	var linkErr *os.LinkError
+	if errors.As(err, &linkErr) && errors.Is(linkErr.Err, syscall.EXDEV) {
+		// Fall back to copy + remove for cross-filesystem move
+		return copyAndRemove(src, dst)
+	}
+
+	// Return original error if not a cross-filesystem issue
+	return err
+}
+
+// copyAndRemove copies src to dst and removes src on success.
+func copyAndRemove(src, dst string) error {
+	// Open source file
+	srcFile, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("error opening source file: %w", err)
+	}
+	defer srcFile.Close()
+
+	// Get source file permissions
+	srcInfo, err := srcFile.Stat()
+	if err != nil {
+		return fmt.Errorf("error getting source file info: %w", err)
+	}
+
+	// Create destination file with same permissions as source
+	dstFile, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, srcInfo.Mode())
+	if err != nil {
+		return fmt.Errorf("error creating destination file: %w", err)
+	}
+
+	// Copy file contents
+	_, err = io.Copy(dstFile, srcFile)
+	if err != nil {
+		_ = dstFile.Close()
+		_ = os.Remove(dst) // Clean up partial file
+		return fmt.Errorf("error copying file: %w", err)
+	}
+
+	// Sync to ensure data is written to disk
+	if err = dstFile.Sync(); err != nil {
+		_ = dstFile.Close()
+		_ = os.Remove(dst) // Clean up
+		return fmt.Errorf("error syncing destination file: %w", err)
+	}
+
+	// Close destination file
+	if err = dstFile.Close(); err != nil {
+		_ = os.Remove(dst) // Clean up
+		return fmt.Errorf("error closing destination file: %w", err)
+	}
+
+	// Remove source file after successful copy
+	if err = os.Remove(src); err != nil {
+		return fmt.Errorf("error removing source file after copy: %w", err)
+	}
+
+	return nil
 }

--- a/fsim/fsim_cross_filesystem_test.go
+++ b/fsim/fsim_cross_filesystem_test.go
@@ -1,0 +1,161 @@
+// SPDX-FileCopyrightText: (C) 2024 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
+
+package fsim
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+)
+
+// TestMoveFile tests same-filesystem move (os.Rename fast path)
+func TestMoveFile(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create source file with specific permissions
+	srcPath := filepath.Join(tmpDir, "source.txt")
+	testContent := []byte("test content")
+	if err := os.WriteFile(srcPath, testContent, 0640); err != nil {
+		t.Fatalf("failed to create source file: %v", err)
+	}
+
+	dstPath := filepath.Join(tmpDir, "destination.txt")
+
+	// Move file (same filesystem - uses os.Rename)
+	if err := moveFile(srcPath, dstPath); err != nil {
+		t.Fatalf("moveFile failed: %v", err)
+	}
+
+	// Verify source is gone
+	if _, err := os.Stat(srcPath); !os.IsNotExist(err) {
+		t.Errorf("source file still exists after move")
+	}
+
+	// Verify destination has correct content
+	gotContent, err := os.ReadFile(dstPath)
+	if err != nil {
+		t.Fatalf("failed to read destination: %v", err)
+	}
+
+	if string(gotContent) != string(testContent) {
+		t.Errorf("content mismatch: got %q, want %q", gotContent, testContent)
+	}
+
+	// Verify permissions preserved
+	info, err := os.Stat(dstPath)
+	if err != nil {
+		t.Fatalf("failed to stat destination: %v", err)
+	}
+
+	if info.Mode().Perm() != 0640 {
+		t.Errorf("permissions not preserved: got %o, want 0640", info.Mode().Perm())
+	}
+}
+
+// TestMoveFileCrossFilesystem tests moveFile across different filesystems
+func TestMoveFileCrossFilesystem(t *testing.T) {
+	// Common filesystem pairs on Linux systems
+	fsPairs := []struct {
+		src  string
+		dst  string
+		desc string
+	}{
+		{"/tmp", "/var/tmp", "tmpfs to disk"},
+		{"/tmp", ".", "tmpfs to current directory"},
+		{"/dev/shm", "/tmp", "shared memory to tmpfs"},
+	}
+
+	var srcBase, dstBase string
+	foundDifferent := false
+
+	// Find two different filesystems
+	for _, pair := range fsPairs {
+		// Check both paths exist
+		if _, err := os.Stat(pair.src); err != nil {
+			continue
+		}
+		if _, err := os.Stat(pair.dst); err != nil {
+			continue
+		}
+
+		// Check if on different filesystems
+		var stat1, stat2 syscall.Stat_t
+		if err := syscall.Stat(pair.src, &stat1); err != nil {
+			continue
+		}
+		if err := syscall.Stat(pair.dst, &stat2); err != nil {
+			continue
+		}
+
+		if stat1.Dev != stat2.Dev {
+			srcBase = pair.src
+			dstBase = pair.dst
+			foundDifferent = true
+			t.Logf("Testing cross-filesystem move: %s", pair.desc)
+			break
+		}
+	}
+
+	if !foundDifferent {
+		t.Skip("No different filesystems found. Test requires RHEL/Fedora with tmpfs /tmp")
+	}
+
+	// Create source file
+	srcFile, err := os.CreateTemp(srcBase, "fsim_test_src_*")
+	if err != nil {
+		t.Fatalf("failed to create source: %v", err)
+	}
+	srcPath := srcFile.Name()
+	defer os.Remove(srcPath)
+
+	testContent := []byte("cross-filesystem test")
+	if _, err := srcFile.Write(testContent); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+	srcFile.Close()
+
+	// Set permissions to verify preservation
+	if err := os.Chmod(srcPath, 0640); err != nil {
+		t.Fatalf("chmod failed: %v", err)
+	}
+
+	// Create destination path on different filesystem
+	dstFile, err := os.CreateTemp(dstBase, "fsim_test_dst_*")
+	if err != nil {
+		t.Fatalf("failed to create dest: %v", err)
+	}
+	dstPath := dstFile.Name()
+	dstFile.Close()
+	os.Remove(dstPath) // Remove it, we just need the path
+	defer os.Remove(dstPath)
+
+	// Move file across filesystems
+	if err := moveFile(srcPath, dstPath); err != nil {
+		t.Fatalf("moveFile failed: %v", err)
+	}
+
+	// Verify source removed
+	if _, err := os.Stat(srcPath); !os.IsNotExist(err) {
+		t.Error("source still exists after move")
+	}
+
+	// Verify destination content
+	got, err := os.ReadFile(dstPath)
+	if err != nil {
+		t.Fatalf("read dest failed: %v", err)
+	}
+	if string(got) != string(testContent) {
+		t.Errorf("content mismatch: got %q, want %q", got, testContent)
+	}
+
+	// Verify permissions preserved
+	info, err := os.Stat(dstPath)
+	if err != nil {
+		t.Fatalf("stat dest failed: %v", err)
+	}
+	if info.Mode().Perm() != 0640 {
+		t.Errorf("permissions not preserved: got %o, want 0640", info.Mode().Perm())
+	}
+}

--- a/fsim/wget_device.go
+++ b/fsim/wget_device.go
@@ -156,7 +156,7 @@ func (d *Wget) download(ctx context.Context, url string) (_ int64, err error) {
 		return 0, fmt.Errorf("checksum of %q failed verification: expected: %x, got: %x", d.name, d.sha384, hashed)
 	}
 
-	// Rename temp file to final file name
+	// Move temp file to final file name
 	resolveName := d.NameToPath
 	if resolveName == nil {
 		resolveName = func(name string) string { return name }
@@ -164,8 +164,8 @@ func (d *Wget) download(ctx context.Context, url string) (_ int64, err error) {
 	if d.name == "" {
 		return 0, fmt.Errorf("name not sent before file download completed")
 	}
-	if err := os.Rename(temp.Name(), resolveName(d.name)); err != nil {
-		return 0, fmt.Errorf("error renaming file to %q: %w", d.name, err)
+	if err := moveFile(temp.Name(), resolveName(d.name)); err != nil {
+		return 0, fmt.Errorf("error moving file to %q: %w", d.name, err)
 	}
 
 	return n, nil


### PR DESCRIPTION
Fixes #210. 
This PR:
- Adds cross-filesystem move support for fdo.download and fdo.wget modules to handle RHEL/Fedora systems where /tmp is tmpfs. Falls back to  copy+remove when os.Rename() fails with EXDEV error across filesystem boundaries.
- Unit test added