### PR TITLE
feat: add failure-aware cleanup for service info modules

### DIFF
--- a/examples/cmd/server.go
+++ b/examples/cmd/server.go
@@ -702,7 +702,7 @@ func (s moduleStateMachines) NextModule(ctx context.Context) (bool, error) {
 	return valid, nil
 }
 
-func (s moduleStateMachines) CleanupModules(ctx context.Context) {
+func (s moduleStateMachines) CleanupModules(ctx context.Context, _ error) {
 	token, ok := s.DB.TokenFromContext(ctx)
 	if !ok {
 		return

--- a/fdotest/client.go
+++ b/fdotest/client.go
@@ -637,7 +637,7 @@ func (s *to2ModuleStateMachine) NextModule(ctx context.Context) (bool, error) {
 	return valid, nil
 }
 
-func (s *to2ModuleStateMachine) CleanupModules(ctx context.Context) {
+func (s *to2ModuleStateMachine) CleanupModules(ctx context.Context, _ error) {
 	if s.module != nil {
 		s.module.Stop()
 		s.module = nil

--- a/http/handler.go
+++ b/http/handler.go
@@ -166,13 +166,17 @@ func (h Handler) handleRequest(ctx context.Context, w http.ResponseWriter, r *ht
 	}
 	if maxSize > 0 && r.ContentLength > maxSize {
 		_ = r.Body.Close()
-		writeErr(w, msgType, fmt.Errorf("content too large (%d bytes)", r.ContentLength))
+		transportErr := fmt.Errorf("content too large (%d bytes)", r.ContentLength)
+		writeErr(w, msgType, transportErr)
+		notifyTransportError(ctx, resp, msgType, transportErr)
 		h.invalidateToken(ctx)
 		return
 	}
 	if maxSize > 0 && r.ContentLength < 0 {
 		_ = r.Body.Close()
-		writeErr(w, msgType, errors.New("content length must be specified in request headers"))
+		transportErr := errors.New("content length must be specified in request headers")
+		writeErr(w, msgType, transportErr)
+		notifyTransportError(ctx, resp, msgType, transportErr)
 		h.invalidateToken(ctx)
 		return
 	}
@@ -196,6 +200,7 @@ func (h Handler) handleRequest(ctx context.Context, w http.ResponseWriter, r *ht
 		}).CryptSession(ctx)
 		if err != nil {
 			writeErr(w, msgType, err)
+			notifyTransportError(ctx, resp, msgType, err)
 			h.invalidateToken(ctx)
 			return
 		}
@@ -204,7 +209,9 @@ func (h Handler) handleRequest(ctx context.Context, w http.ResponseWriter, r *ht
 
 		decrypted, err := sess.Decrypt(rand.Reader, msg)
 		if err != nil {
-			writeErr(w, msgType, fmt.Errorf("error decrypting message %d: %w", msgType, err))
+			transportErr := fmt.Errorf("error decrypting message %d: %w", msgType, err)
+			writeErr(w, msgType, transportErr)
+			notifyTransportError(ctx, resp, msgType, transportErr)
 			h.invalidateToken(ctx)
 			return
 		}
@@ -236,6 +243,7 @@ func (h Handler) writeResponse(ctx context.Context, w http.ResponseWriter, msgTy
 		}).CryptSession(ctx)
 		if err != nil {
 			writeErr(w, msgType, err)
+			notifyTransportError(ctx, resp, msgType, err)
 			h.invalidateToken(ctx)
 			return
 		}
@@ -248,7 +256,9 @@ func (h Handler) writeResponse(ctx context.Context, w http.ResponseWriter, msgTy
 
 		respData, err = sess.Encrypt(rand.Reader, respData)
 		if err != nil {
-			writeErr(w, msgType, fmt.Errorf("error encrypting message %d: %w", respType, err))
+			transportErr := fmt.Errorf("error encrypting message %d: %w", respType, err)
+			writeErr(w, msgType, transportErr)
+			notifyTransportError(ctx, resp, msgType, transportErr)
 			h.invalidateToken(ctx)
 			return
 		}
@@ -263,7 +273,9 @@ func (h Handler) writeResponse(ctx context.Context, w http.ResponseWriter, msgTy
 	// Marshal response to get size
 	var body bytes.Buffer
 	if err := cbor.NewEncoder(&body).Encode(respData); err != nil {
-		writeErr(w, msgType, fmt.Errorf("error marshaling response message %d: %w", respType, err))
+		transportErr := fmt.Errorf("error marshaling response message %d: %w", respType, err)
+		writeErr(w, msgType, transportErr)
+		notifyTransportError(ctx, resp, msgType, transportErr)
 		h.invalidateToken(ctx)
 		return
 	}
@@ -280,6 +292,16 @@ func (h Handler) writeResponse(ctx context.Context, w http.ResponseWriter, msgTy
 		writeErr(w, msgType, fmt.Errorf("error writing response message %d: %w", respType, err))
 		h.invalidateToken(ctx)
 		return
+	}
+}
+
+// notifyTransportError calls HandleTransportError on the responder if it
+// implements the optional TransportErrorHandler interface. This ensures that
+// responders like TO2Server can clean up module resources even when the HTTP
+// transport layer fails before reaching Respond().
+func notifyTransportError(ctx context.Context, resp protocol.Responder, msgType uint8, err error) {
+	if th, ok := resp.(protocol.TransportErrorHandler); ok {
+		th.HandleTransportError(ctx, msgType, err)
 	}
 }
 

--- a/protocol/responder.go
+++ b/protocol/responder.go
@@ -17,3 +17,15 @@ type Responder interface {
 	// HandleError performs session cleanup before the token is invalidated.
 	HandleError(context.Context, ErrorMessage)
 }
+
+// TransportErrorHandler is an optional interface that Responders may implement
+// to perform cleanup when the HTTP transport layer encounters an error (e.g.
+// content too large, decryption failure). These errors bypass the normal
+// Respond() path and therefore bypass any cleanup that Respond() would do.
+//
+// This is primarily useful for TO2Server, where modules may have created
+// resources (upload directories, temp files) that need cleanup even when the
+// transport layer fails.
+type TransportErrorHandler interface {
+	HandleTransportError(ctx context.Context, msgType uint8, err error)
+}

--- a/server.go
+++ b/server.go
@@ -306,10 +306,12 @@ func (s *TO2Server) Respond(ctx context.Context, msgType uint8, msg io.Reader) (
 		respType = protocol.TO2OwnerServiceInfoMsgType
 		resp, err = s.ownerServiceInfo(ctx, msg)
 		if err != nil {
-			s.Modules.CleanupModules(ctx)
+			s.cleanupCurrentModule(ctx, err)
+			s.Modules.CleanupModules(ctx, err)
 		}
 	case protocol.TO2DoneMsgType:
-		s.Modules.CleanupModules(ctx)
+		s.cleanupCurrentModule(ctx, nil)
+		s.Modules.CleanupModules(ctx, nil)
 		respType = protocol.TO2Done2MsgType
 		resp, err = s.to2Done2(ctx, msg)
 	}
@@ -344,5 +346,29 @@ func (s *TO2Server) CryptSession(ctx context.Context) (kex.Session, error) {
 func (s *TO2Server) HandleError(ctx context.Context, errMsg protocol.ErrorMessage) {
 	// This should only be applicable if errMsg.PrevMsgType == 69, but the
 	// device reported error message cannot be completely trusted
-	s.Modules.CleanupModules(ctx)
+	s.Modules.CleanupModules(ctx, fmt.Errorf("device error (message %d): %s", errMsg.PrevMsgType, errMsg.ErrString))
+}
+
+// HandleTransportError performs module cleanup when the HTTP transport layer
+// encounters an error during an active TO2 session (e.g. decryption failure,
+// content too large). These errors bypass Respond() and would otherwise skip
+// module cleanup entirely.
+func (s *TO2Server) HandleTransportError(ctx context.Context, _ uint8, err error) {
+	transportErr := fmt.Errorf("transport error: %w", err)
+	s.cleanupCurrentModule(ctx, transportErr)
+	s.Modules.CleanupModules(ctx, transportErr)
+}
+
+// cleanupCurrentModule calls Cleanup on the current active module if it
+// implements the optional serviceinfo.Cleanup interface. This allows modules
+// to clean up their own private resources (temp files, file handles, channels)
+// that are not accessible from the ModuleStateMachine.
+func (s *TO2Server) cleanupCurrentModule(ctx context.Context, err error) {
+	_, mod, modErr := s.Modules.Module(ctx)
+	if modErr != nil {
+		return // no active module
+	}
+	if c, ok := mod.(serviceinfo.Cleanup); ok {
+		c.Cleanup(ctx, err)
+	}
 }

--- a/serviceinfo/cleanup.go
+++ b/serviceinfo/cleanup.go
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
+
+package serviceinfo
+
+import "context"
+
+// Cleanup is an optional interface that OwnerModule implementations may
+// implement to clean up internal resources when TO2 completes or fails.
+//
+// This is useful for modules that hold private state such as temp files,
+// open file handles, or channels that cannot be cleaned up externally.
+//
+// The error parameter indicates whether TO2 completed successfully (nil)
+// or failed (non-nil). Implementations can use this to decide whether to
+// keep or remove resources. For example, an upload module may delete its
+// temp file on failure but keep it on success.
+type Cleanup interface {
+	Cleanup(ctx context.Context, err error)
+}

--- a/serviceinfo/module_state_machine.go
+++ b/serviceinfo/module_state_machine.go
@@ -64,7 +64,12 @@ type ModuleStateMachine interface {
 	// CleanupModules cleans up any internal state. When the context expires,
 	// all remaining cleanup should be forced (i.e. processes killed) without
 	// waiting for graceful exit.
-	CleanupModules(context.Context)
+	//
+	// The error parameter indicates whether TO2 completed successfully
+	// (nil) or failed (non-nil). Implementations can use this to decide
+	// whether to keep or remove resources created during service info
+	// exchange (e.g. upload directories).
+	CleanupModules(context.Context, error)
 }
 
 // ModulePersister is an optional interface which may be implemented by


### PR DESCRIPTION
(Keeping in draft untill we agree on the discussion #247 )
  Add failure-aware cleanup for service info modules so implementations can
  clean up resources (upload directories, temp files) on TO2 failure.

  - Add error parameter to `CleanupModules(ctx, error)`
  - Add optional `serviceinfo.Cleanup` interface for per-module cleanup
  - Add optional `TransportErrorHandler` interface for HTTP-level errors

  See discussion: (https://github.com/fido-device-onboard/go-fdo/discussions/247)

  Relates to #214
