### PR TITLE
cbor: reject oversized unwrapped lengths

### DIFF
--- a/cbor/unwrap.go
+++ b/cbor/unwrap.go
@@ -17,7 +17,13 @@ var ErrNullOrUndefined = fmt.Errorf("null or undefined")
 //
 // If the next value is the undefined or null simple value, err will wrap
 // ErrNullOrUndefined.
-func (d *Decoder) UnwrapArray() (uint64, error) { return d.unwrap(arrayMajorType) }
+func (d *Decoder) UnwrapArray() (uint64, error) {
+	n, err := d.unwrap(arrayMajorType)
+	if n > MaxArrayDecodeLength {
+		return 0, fmt.Errorf("length exceeds max size: %d", n)
+	}
+	return n, err
+}
 
 // UnwrapBytes ensures the next type to decode is either a text or byte string
 // and returns its length, progressing the underlying reader to the start of
@@ -26,7 +32,11 @@ func (d *Decoder) UnwrapArray() (uint64, error) { return d.unwrap(arrayMajorType
 // If the next value is the undefined or null simple value, err will wrap
 // ErrNullOrUndefined.
 func (d *Decoder) UnwrapBytes() (uint64, error) {
-	return d.unwrap(byteStringMajorType, textStringMajorType)
+	n, err := d.unwrap(byteStringMajorType, textStringMajorType)
+	if n > MaxArrayDecodeLength {
+		return 0, fmt.Errorf("length exceeds max size: %d", n)
+	}
+	return n, err
 }
 
 // Untag ensures the next type to decode is a tag and returns the tag number,

--- a/cbor/unwrap_test.go
+++ b/cbor/unwrap_test.go
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: (C) 2026 Flavien Solt
+// SPDX-License-Identifier: Apache 2.0
+
+package cbor_test
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/fido-device-onboard/go-fdo/cbor"
+)
+
+func TestUnwrapLengthLimit(t *testing.T) {
+	maxLength := ^uint64(0)
+	wantErr := fmt.Sprintf("length exceeds max size: %d", maxLength)
+
+	for _, test := range []struct {
+		name   string
+		head   byte
+		unwrap func(*cbor.Decoder) (uint64, error)
+	}{
+		{name: "array", head: 0x9b, unwrap: (*cbor.Decoder).UnwrapArray},
+		{name: "bytes", head: 0x5b, unwrap: (*cbor.Decoder).UnwrapBytes},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			data := append([]byte{test.head}, bytes.Repeat([]byte{0xff}, 8)...)
+			length, err := test.unwrap(cbor.NewDecoder(bytes.NewReader(data)))
+			if err == nil || err.Error() != wantErr {
+				t.Fatalf("length=%d err=%v, want length=0 err=%q", length, err, wantErr)
+			}
+			if length != 0 {
+				t.Fatalf("length=%d, want 0", length)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Reject oversized lengths from `UnwrapArray` and `UnwrapBytes` before custom decoders allocate from them. Add regression coverage for both paths.

Test: `go test ./cbor`
